### PR TITLE
쓰레기통 추가신청 페이지로 이동하는 기능 구현

### DIFF
--- a/lib/pages/main-drawer.dart
+++ b/lib/pages/main-drawer.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:client/pages/trash-add.dart';
+import 'package:get/get.dart';
 
 class MainDrawer extends StatelessWidget {
   const MainDrawer({ Key? key }) : super(key: key);
@@ -71,9 +73,18 @@ class MenuPart extends StatelessWidget {
       child: Container(
         child: ListView(
           children: [
-            ListTile(title: Text("쓰레기통 추가신청"),),
-            ListTile(title: Text("쓰레기통 철거신청"),),
-            ListTile(title: Text("쓰레기통 청소신청"),),
+            ListTile(
+              onTap: () {
+                Get.to(() => const TrashAddPage());  // 쓰레기통 추가신청 페이지로 이동
+              },
+              title: Text("쓰레기통 추가신청"),
+            ),
+            ListTile(
+              title: Text("쓰레기통 철거신청"),
+            ),
+            ListTile(
+              title: Text("쓰레기통 청소신청"),
+            ),
           ],
         ),
       ),

--- a/lib/pages/trash-add.dart
+++ b/lib/pages/trash-add.dart
@@ -1,0 +1,61 @@
+// 쓰레기통 추가신청 페이지
+import 'package:flutter/material.dart';
+
+class TrashAddPage extends StatelessWidget {
+  const TrashAddPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('쓰레기통 추가신청'),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            TextButton(
+              onPressed: (){
+                  showDialog(
+                    context: context,
+                    barrierDismissible: false,
+                    builder: (BuildContext context) {
+                      return AlertDialog(
+                        title: Text('신청하기'),
+                        content: SingleChildScrollView(
+                          child: Text('미구현입니다.'),
+                          ),
+                        actions: <Widget>[
+                          TextButton(
+                            child: Text('확인'),
+                            onPressed: () {
+                              Navigator.of(context).pop();
+                            }
+                          ),
+                          TextButton(
+                            child: Text('취소'),
+                            onPressed: () {
+                              Navigator.of(context).pop();
+                            },
+                          ),
+                        ],
+                      );
+                    }
+                  );
+                },
+              child: Text(
+                '신청하기',
+                style: TextStyle(
+                  fontSize: 20.0,
+                ),
+              ),
+              style: TextButton.styleFrom(
+                primary: Colors.red,
+              ),
+            )
+          ],
+        )
+      )
+    );
+  }
+}


### PR DESCRIPTION
## 개요
- 메뉴에서 쓰레기통 추가신청 버튼을 누르면 쓰레기통 추가신청 페이지로 이동하는 기능.

## ⛑ 주의할 점
- 의존성주입은 다음에 적용해볼 예정입니다.
- iOS 빌드 오류 수정하느라고 시간을 너무 많이 썼어요. ㅠㅠ

## 🛎 작업 내용
- main-drawer.dart 수정
- trash-add.dart 생성
