### PR TITLE
FIX: Marker의 크기 조정

### DIFF
--- a/lib/pages/main-map.dart
+++ b/lib/pages/main-map.dart
@@ -71,6 +71,8 @@ class NaverMapBody extends State {
           markerId: coordinate['id'].toString(), 
           position: LatLng(
             double.parse(coordinate['latitude']), double.parse(coordinate['longitude'])),
+          width: 20,
+          height: 30,
           ),
         );
       }


### PR DESCRIPTION
## 개요
- 지도의 마커의 크기를 줄였습니다.

## ⛑ 주의할 점
- 최대 줌아웃 범위도 설정하려고 했으나, 패키지에서 지원되지 않아 못하였습니다.
- 프로토타입 제작후, 패키지를 한 번 갈아엎을 예정입니다.

## 🛎 작업 내용
- 지도의 마커 크기 줄임.
