### PR TITLE
FIX: 쓰레기통 추가 위젯 코드의 null aware 연산자 삭제

### DIFF
--- a/lib/widgets/trash-manage.dart
+++ b/lib/widgets/trash-manage.dart
@@ -49,8 +49,8 @@ class _TrashAddWidgetState extends State<TrashAddWidget> {
       onTap: () async {
         Position position;
         position = await GeolocatorService().getCurrentPosition();
-        final latitude = position!.latitude;
-        final longitude = position!.longitude;
+        final latitude = position.latitude;
+        final longitude = position.longitude;
         showDialog(
           context: context,
           builder: (BuildContext context) => AlertDialog(


### PR DESCRIPTION
## 개요
- 쓰레기통 추가 위젯 코드의 null aware 연산자 삭제

## ⛑ 주의할 점
- 

## 🛎 작업 내용
- TrashAddWidget의 build에 불필요한 null aware 연산자 삭제

