### PR TITLE
fix: main-map.dart 위젯 분리 및 GetX 일부 적용

### DIFF
--- a/lib/controllers/dropdown-controller.dart
+++ b/lib/controllers/dropdown-controller.dart
@@ -1,0 +1,16 @@
+import 'package:get/get.dart';
+
+class DropdownController extends GetxController {
+  RxString _dropdownValue = '모든 쓰레기통'.obs;
+  final List<String> _valueList = ['모든 쓰레기통', '일반 쓰레기통', '재활용 쓰레기통'];
+
+  RxString get dropdownValue => _dropdownValue;
+  List<String> get valueList => _valueList;
+
+  set dropdownValue(RxString value) => _dropdownValue = value;
+
+  changeValue(RxString selectedValue) {
+    _dropdownValue = selectedValue;
+    update();
+  }
+}

--- a/lib/pages/main-page.dart
+++ b/lib/pages/main-page.dart
@@ -1,0 +1,37 @@
+import 'package:client/pages/loading.dart';
+import 'package:client/pages/main-drawer.dart';
+import 'package:client/widgets/camera.dart';
+import 'package:client/widgets/main-map.dart';
+import 'package:flutter/material.dart';
+
+// MainPage stateless로 변경
+class MainPage extends StatelessWidget {
+  const MainPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      drawer: MainDrawer(),
+      appBar: AppBar(title: Text('가로쓰레기통 알리미')),
+      body: NaverMapWidget(),
+      bottomNavigationBar: MainBottomNavBar(),
+    );
+  }
+}
+
+//Bottom Navigation Bar
+class MainBottomNavBar extends StatelessWidget {
+  const MainBottomNavBar({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return BottomAppBar(
+      child: Container(
+        alignment: Alignment.center,
+        height: 70,
+        color: Colors.lightBlue,
+        child: UseCamera(),
+      ),
+    );
+  }
+}

--- a/lib/widgets/main-map.dart
+++ b/lib/widgets/main-map.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'package:client/controllers/dropdown-controller.dart';
 import 'package:client/pages/loading.dart';
 import 'package:client/utils/geolocator-service.dart';
 import 'package:client/pages/main-drawer.dart';
@@ -7,43 +8,9 @@ import 'package:client/widgets/camera.dart';
 import 'package:flutter/material.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:naver_map_plugin/naver_map_plugin.dart';
+import 'package:get/get.dart'; // 상태관리용 GetX 패키지
 
 NaverMapBody naverMapBody = NaverMapBody();
-
-class MainPage extends StatefulWidget {
-  @override
-  _StartMainPage createState() => _StartMainPage();
-}
-
-//Main page 시작
-class _StartMainPage extends State<MainPage> {
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      drawer: MainDrawer(),
-      appBar: AppBar(title: Text('가로쓰레기통 알리미')),
-      body: NaverMapWidget(),
-      bottomNavigationBar: MainBottomNavBar(),
-    );
-  }
-}
-
-//Bottom Navigation Bar
-class MainBottomNavBar extends StatelessWidget {
-  const MainBottomNavBar({Key? key}) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    return BottomAppBar(
-      child: Container(
-        alignment: Alignment.center,
-        height: 70,
-        color: Colors.lightBlue,
-        child: UseCamera(),
-      ),
-    );
-  }
-}
 
 class NaverMapWidget extends StatefulWidget {
   const NaverMapWidget({Key? key}) : super(key: key);
@@ -141,7 +108,7 @@ class NaverMapBody extends State {
               )),
           Align(
             alignment: Alignment.topCenter,
-            child: TrashClassification(),
+            child: TrashClassificationDropdownButton(), // 쓰레기통 종류 드랍다운
           ),
           Positioned(
             bottom: 10,
@@ -245,75 +212,69 @@ class RefreshBtn extends StatelessWidget {
   }
 }
 
-//드롭다운버튼
-class TrashClassification extends StatefulWidget {
-  const TrashClassification({Key? key}) : super(key: key);
+// 쓰레기통종류 드랍다운 버튼 with GetX
+class TrashClassificationDropdownButton extends StatelessWidget {
+  TrashClassificationDropdownButton({Key? key}) : super(key: key);
 
-  @override
-  _TrashClassificationState createState() => _TrashClassificationState();
-}
-
-//드롭다운 버튼의 create상태
-class _TrashClassificationState extends State {
-  String? dropdownValue = '모든 쓰레기통';
-  final List<String> _valueList = ['모든 쓰레기통', '일반 쓰레기통', '재활용 쓰레기통'];
+  DropdownController dropdownController =
+      Get.put(DropdownController()); // DropdownController 의존성 주입
 
   @override
   Widget build(BuildContext context) {
     return Container(
-      width: 150,
-      height: 40,
-      decoration: BoxDecoration(
-        color: Colors.grey.shade50,
-        border: Border.all(
-          color: Colors.black,
-          width: 0.3,
+        width: 150,
+        height: 40,
+        decoration: BoxDecoration(
+          color: Colors.grey.shade50,
+          border: Border.all(
+            color: Colors.black,
+            width: 0.3,
+          ),
+          borderRadius: BorderRadius.circular(20),
         ),
-        borderRadius: BorderRadius.circular(20),
-      ),
-      margin: EdgeInsets.fromLTRB(0, 10, 0, 0),
-      child: DropdownButton<String>(
-        isExpanded: true,
-        alignment: Alignment.centerRight,
-        borderRadius: BorderRadius.circular(20),
-        value: dropdownValue,
-        icon: Icon(Icons.arrow_drop_down),
-        iconSize: 0,
-        elevation: 16,
-        underline: Container(
-          color: Colors.transparent,
-        ),
-        style: TextStyle(
-          color: Colors.black,
-          fontSize: 18,
-        ),
-        onChanged: (String? data) {
-          setState(() {
-            dropdownValue = data;
-            switch (data) {
-              case '일반 쓰레기통':
-                naverMapBody.type = 1;
-                break;
-              case '재활용 쓰레기통':
-                naverMapBody.type = 2;
-                break;
-              default:
-                naverMapBody.type = null;
-                break;
-            }
-          });
-        },
-        items: _valueList.map((String value) {
-          return DropdownMenuItem(
-            value: value,
-            child: Center(
-                child: Text(
-              value,
-              textAlign: TextAlign.center,
-            )),
-          );
-        }).toList(),
-      ),
-    );
+        margin: EdgeInsets.fromLTRB(0, 10, 0, 0),
+        // 드랍다운 버튼
+        child: Obx(
+          () => DropdownButton<String>(
+            isExpanded: true,
+            alignment: Alignment.centerRight,
+            borderRadius: BorderRadius.circular(20),
+            value: dropdownController.dropdownValue.value,
+            icon: Icon(Icons.arrow_drop_down),
+            iconSize: 0,
+            elevation: 16,
+            underline: Container(
+              color: Colors.transparent,
+            ),
+            style: TextStyle(
+              color: Colors.black,
+              fontSize: 18,
+            ),
+            onChanged: (String? data) {
+              dropdownController.dropdownValue.value = data!;
+              switch (data) {
+                case '일반 쓰레기통':
+                  naverMapBody.type = 1;
+                  break;
+                case '재활용 쓰레기통':
+                  naverMapBody.type = 2;
+                  break;
+                default:
+                  naverMapBody.type = null;
+                  break;
+              }
+            },
+            items: dropdownController.valueList.map((String value) {
+              return DropdownMenuItem(
+                value: value,
+                child: Center(
+                    child: Text(
+                  value,
+                  textAlign: TextAlign.center,
+                )),
+              );
+            }).toList(),
+          ),
+        ));
   }
 }


### PR DESCRIPTION
## 개요
- 메인지도의 반응속도 향상

## ⛑ 주의할 점
- `main-map.dart` 파일을 분리해서 각각 `main-page.dart` 와 `main-map.dart` 로 분리
- `main-map.dart` 는 기존 네이버 지도 패키지 자체가 네이버 공식 패키지가 아니라 코드가 매우 복잡한데다가 여러 코드가 짬뽕되어 있어서 리팩토링 매우 험난할 것으로 예상 (현재 약 40% 완료)

## 🛎 작업 내용
- `/lib/pages/main-page.dart` 에는 정말 화면을 구성하는 요소로 이루어진 위젯들만 남김, main-map.dart를 참조하는 형태
- `/lib/widgets/main-map.dart` 에는 네이버 지도 관련 위젯들만 남김
- `/lib/controllers` 디렉토리 생성 -> GetX를 위한 컨트롤러 위젯 모아서 관리할 예정
- `dropdown-controller.dart` 메인지도 DropdownButton을 위한 GetX Controller 작성
- `main-map.dart` 메인지도 상단 중앙 DropdownButton 위젯 GetX를 사용해 Stateless Widget으로 코드 재작성
- `main-page.dart` 메인페이지 위젯 Stateful -> Stateless 로 변경