### PR TITLE
REFACTOR: camera.dart에 GetX를 이용한 상태관리 적용

### DIFF
--- a/lib/controllers/camera-controller.dart
+++ b/lib/controllers/camera-controller.dart
@@ -1,0 +1,41 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:get/get.dart' hide FormData, MultipartFile;
+import 'package:get/get_state_manager/get_state_manager.dart';
+import 'package:image_picker/image_picker.dart';
+
+class CameraController extends GetxController {
+
+  final ImagePicker _picker = ImagePicker();
+  XFile? image;
+
+  Future getImage(ImageSource imageSource) async {
+    FormData? _formData;
+    final XFile? pickedFile = await _picker.pickImage(
+      source: imageSource,
+      imageQuality: 30,
+    );
+    if(pickedFile != null) {
+      image = XFile(pickedFile.path);
+    }
+
+    if(image != null) {
+      _formData = FormData.fromMap({"file": MultipartFile.fromFileSync(image!.path)});
+    }
+
+    update();
+
+    //NOTE: 이 부분은 나중에 서버와의 통신을 위해 사용해야할 부분입니다.
+    Dio dio = Dio();
+
+    // dio.options.headers["authorization"] = AuthProvider.token;
+    dio.options.contentType = "multipart/form-data";
+    final res = await dio.post("${dotenv.get('FLASK_BASE_URL')}/predict/", data: _formData )
+      .then((res) {
+        Get.back();
+        return res.data;
+      });
+
+    return res;
+  }
+}

--- a/lib/widgets/camera.dart
+++ b/lib/widgets/camera.dart
@@ -1,57 +1,18 @@
-import 'package:dio/dio.dart';
+import 'package:client/controllers/camera-controller.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
-import 'package:get/get.dart' hide FormData, MultipartFile;
+import 'package:get/get.dart';
 import 'package:image_picker/image_picker.dart';
 
-class UseCamera extends StatefulWidget {
-  const UseCamera({ Key? key }) : super(key: key);
+class UseCamera extends StatelessWidget {
 
-  @override
-  State<UseCamera> createState() => _UseCameraState();
-}
-
-class _UseCameraState extends State<UseCamera> {
-  final ImagePicker _picker = ImagePicker();
-  XFile? _image;
+  final controller = Get.put(CameraController());
 
   @override
   Widget build(BuildContext context) {
-    
-    Future getImage(ImageSource imageSource) async {
-      FormData? _formData;
-      final XFile? pickedFile = await _picker.pickImage(
-        source: imageSource,
-        imageQuality: 30,
-      );
-      if(pickedFile != null) {
-        setState(() {
-          _image = XFile(pickedFile.path);
-        }); 
-      }
-
-      if(_image != null) {
-        _formData = FormData.fromMap({"file": MultipartFile.fromFileSync(_image!.path)});
-      }
-
-      //NOTE: 이 부분은 나중에 서버와의 통신을 위해 사용해야할 부분입니다.
-      Dio dio = Dio();
-
-      // dio.options.headers["authorization"] = AuthProvider.token;
-      dio.options.contentType = "multipart/form-data";
-      final res = await dio.post("${dotenv.get('FLASK_BASE_URL')}/predict/", data: _formData )
-        .then((res) {
-          Get.back();
-          return res.data;
-        });
-
-      return res;
-    }
-
     return IconButton(
       onPressed: () async {
         //카메라 버튼이 눌렸을 경우 실행되는 함수
-        final data = await getImage(ImageSource.camera);
+        final data = await controller.getImage(ImageSource.camera);
         final label = data['predicted_label'];
         print(label);
         showDialog(
@@ -68,6 +29,3 @@ class _UseCameraState extends State<UseCamera> {
     );
   }
 }
-
-
-

--- a/lib/widgets/camera.dart
+++ b/lib/widgets/camera.dart
@@ -1,7 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
-import 'package:get/get.dart' as g;
+import 'package:get/get.dart' hide FormData, MultipartFile;
 import 'package:image_picker/image_picker.dart';
 
 class UseCamera extends StatefulWidget {
@@ -41,7 +41,7 @@ class _UseCameraState extends State<UseCamera> {
       dio.options.contentType = "multipart/form-data";
       final res = await dio.post("${dotenv.get('FLASK_BASE_URL')}/predict/", data: _formData )
         .then((res) {
-          g.Get.back();
+          Get.back();
           return res.data;
         });
 


### PR DESCRIPTION
## 개요
- `camera.dart`파일의 코드를 GetX를 이용한 상태관리 코드로 수정.

## ⛑ 주의할 점
- 아직 GetX에 대해 완전히 이해하지 못하고 작성한 코드이기 때문에, 부족한 부분이 보일 수 있습니다. (보인다면 피드백 주세요)

## 🛎 작업 내용
- `/lib/controllers/camera-controller.dart`파일 생성
  - getImage() : 이미지를 가져온 후, 서버에서 쓰레기 분류에 대한 결과물을 받아오는 메서드
- `/lib/widgets/camera.dart`파일 Getx를 이용한 상태관리 코드로 리팩토링
  - StatefulWidget과 State를 제거하였습니다.