### PR TITLE
FEAT: 쓰레기 촬영 후 유형에 맞는 가장 가까운 쓰레기통 보여주는 기능

### DIFF
--- a/lib/controllers/main-map-controller.dart
+++ b/lib/controllers/main-map-controller.dart
@@ -1,0 +1,129 @@
+import 'dart:async';
+
+import 'package:get/get.dart';
+import 'package:naver_map_plugin/naver_map_plugin.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:client/utils/main-service.dart';
+import 'package:flutter/material.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:client/utils/geolocator-service.dart';
+
+MainMapController mainMapController = Get.put(MainMapController());
+
+class MainMapController extends GetxController {
+  int _analysisData = 1;
+
+  String _address = '';
+  List<String> _trashcanStringType = ['쓰레기통', '일반 쓰레기통', '재활용 쓰레기통'];
+  int _trashcanType = 0;
+  int? _trashcanId;
+  bool _isVisible = false;
+
+  List<Marker> _markers = [];
+  Completer<NaverMapController> _controller = Completer();
+  MapType _mapType = MapType.Basic;
+  Position? _position;
+
+  List<Marker> get markers => _markers;
+  Completer<NaverMapController> get controller => _controller;
+  MapType get mapType => _mapType;
+  Position? get position => _position;
+
+  set markers(List<Marker> list) => _markers = list;
+  set mapType(MapType type) => _mapType = type;
+  set position(Position? pos) => _position = pos;
+  set controller(Completer<NaverMapController> com) => _controller = com;
+
+  int? _type = null;
+
+  int? get type => _type;
+  set type(int? type) => _type = type;
+
+  int get analysisData => _analysisData;
+
+  set analysisData(int data) => _analysisData = data;
+
+  String get address => _address;
+  List<String> get trashcanStringType => _trashcanStringType;
+  int get trashcanType => _trashcanType;
+  int? get trashcanId => _trashcanId;
+  bool get isVisible => _isVisible;
+
+  set address(String address) => _address = address;
+  set trashcanType(int type) => _trashcanType = type;
+  set trashcanId(int? id) => _trashcanId = id;
+  set isVisible(bool bool) => _isVisible = bool;
+
+  @override
+  void setMarker(List coordinates) {
+    markers.clear();
+    for (final coordinate in coordinates) {
+      markers.add(
+        Marker(
+          markerId: coordinate['id'].toString(),
+          position: LatLng(double.parse(coordinate['latitude']),
+              double.parse(coordinate['longitude'])),
+          width: 20,
+          height: 30,
+          onMarkerTab: (marker, iconSize) {
+            address = coordinate['address'];
+            trashcanType = coordinate['type'];
+            trashcanId = coordinate['id'];
+            isVisible = true;
+            update();
+          },
+        ),
+      );
+    }
+    update();
+  }
+
+  @override
+  void onInit() {
+    super.onInit();
+    WidgetsBinding.instance?.addPostFrameCallback((_) {
+      _initGetCoordinate();
+    });
+    update();
+  }
+
+  @override
+  void _initGetCoordinate() async {
+    position = await GeolocatorService().getCurrentPosition();
+    final latitude = position?.latitude;
+    final longitude = position?.longitude;
+
+    final data = await coordinates(latitude!, longitude!, type);
+    setMarker(data);
+    update();
+  }
+
+  @override
+  void falseIsVisible() {
+    isVisible = false;
+    update();
+  }
+
+  @override
+  void nearestTrashcan() async {
+    position = await GeolocatorService().getCurrentPosition();
+    final latitude = mainMapController.position?.latitude;
+    final longitude = mainMapController.position?.longitude;
+
+    dynamic nearestTrashcan = await getNearestTrashcan(
+        latitude!, longitude!, mainMapController.analysisData);
+
+    if (nearestTrashcan == "") {
+      print("주변에 쓰레기통이 없습니다.");
+      nearestTrashcan =
+          await getNearestTrashcan(37.602638, 126.955252, analysisData);
+    }
+
+    address = nearestTrashcan['address'];
+    trashcanId = nearestTrashcan['id'];
+    trashcanType = nearestTrashcan['type'];
+    isVisible = true;
+
+    update();
+  }
+}

--- a/lib/utils/main-service.dart
+++ b/lib/utils/main-service.dart
@@ -75,3 +75,35 @@ Future applyCleaning(int trashcanId, int note) async {
     print(e);
   }
 }
+
+Future getNearestTrashcan(double latitude, double longitude, int? type) async {
+  BaseOptions options = BaseOptions(
+    baseUrl: '${dotenv.get('NEST_BASE_URL')}',
+    connectTimeout: 5000,
+    receiveTimeout: 3000,
+  );
+
+  Dio dio = Dio(options);
+
+  Response? response;
+
+  Map<String, dynamic> query = {
+    'lat': latitude,
+    'lon': longitude,
+  };
+
+  if (type != null) {
+    query['type'] = type;
+  }
+
+  try {
+    response = await dio.get(
+      '/trashcan/nearest',
+      queryParameters: query,
+    );
+  } on Exception catch (e) {
+    print(e);
+  }
+
+  return response!.data;
+}

--- a/lib/widgets/camera.dart
+++ b/lib/widgets/camera.dart
@@ -1,11 +1,18 @@
 import 'package:client/controllers/camera-controller.dart';
+import 'package:client/controllers/main-map-controller.dart';
+import 'package:client/utils/geolocator-service.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:image_picker/image_picker.dart';
+import 'main-map.dart';
+import 'package:client/utils/main-service.dart';
+import 'package:geolocator/geolocator.dart';
 
 class UseCamera extends StatelessWidget {
-
   final controller = Get.put(CameraController());
+
+  MainMapController mainMapController =
+      Get.put(MainMapController()); // MainMapController 의존성 주입
 
   @override
   Widget build(BuildContext context) {
@@ -14,18 +21,40 @@ class UseCamera extends StatelessWidget {
         //카메라 버튼이 눌렸을 경우 실행되는 함수
         final data = await controller.getImage(ImageSource.camera);
         final label = data['predicted_label'];
+        if (label == '고철류' ||
+            label == '도기류' ||
+            label == '스티로폼' ||
+            label == '유리병' ||
+            label == '자전거' ||
+            label == '전자제품' ||
+            label == '캔류' ||
+            label == '페트병' ||
+            label == '플라스틱류' ||
+            label == '형광등') {
+          mainMapController.analysisData = 2;
+        } else {
+          mainMapController.analysisData = 1;
+        }
+
         print(label);
         showDialog(
-          context: context, 
+          context: context,
           builder: (BuildContext context) => AlertDialog(
             title: Text("쓰레기통 분류"),
             content: Text("분류 : ${label}"),
+            actions: [
+              FlatButton(
+                  child: Text("쓰레기통 찾기"),
+                  onPressed: () {
+                    Navigator.of(context).pop();
+                    mainMapController.nearestTrashcan();
+                  }),
+            ],
           ),
         );
       },
       icon: Icon(Icons.camera),
       iconSize: 60,
-      
     );
   }
 }


### PR DESCRIPTION
## 개요
- 쓰레기 촬영 후 유형에 맞는 가장 가까운 쓰레기통 보여주는 기능

## ⛑ 주의할 점
- 주석이 거의 안 되어 있음
- 반경 1km 내에 쓰레기통이 없는 경우 서버에서 그냥 빈값을 반환해주기 때문에, 쓰레기통이 없는 경우 임의로 위치를 상명대 공학관으로 변경해서 다시 받아옴. -> 추후에 주변에 쓰레기통이 없다는 경고창으로 수정 예정
- 쓰레기통 찾기 버튼 누르면 쓰레기통 정보만 뜨고 지도는 안 움직이는데 이것도 CameraPosition 활용해서 다음에 수정 예정

## 🛎 작업 내용
- `main-map.dart` 수정 -> GetX 적용 -> 싹 갈아 엎어짐 
- **이제 일반, 재활용 쓰레기통 목록에서 선택 시 새로고침 버튼을 누르지 않아도 선택하자마자 지도가 refresh 됩니다.**
- `main-map-controller.dart` 생성 -> GetX 컨트롤러
- `main-service.dart` 수정 -> 유형별 가장 가까운 쓰레기통 요청하는 기능 추가
- `camera.dart` 수정 -> 카메라 촬영 시 분류 창에 쓰레기통 찾기 기능 추가 -> 쓰레기통 찾기를 누르면 쓰레기통 정보가 뜸
