### PR TITLE
FIX: 안드로이드 패키지 명 변경에 따른 파일 수정

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -47,7 +47,7 @@ android {
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId "com.smu-capstone-bigdata.client"
+        applicationId "com.smu_capstone_bigdata.client"
         minSdkVersion flutter.minSdkVersion
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()

--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.client">
+    package="com.smu_capstone_bigdata.client">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.smu-capstone-bigdata.client">
+    package="com.smu_capstone_bigdata.client">
    <application
         android:label="가로쓰레기통 알리미"
         android:name="${applicationName}"

--- a/android/app/src/main/kotlin/com/smu_capstone_bigdata/client/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/smu_capstone_bigdata/client/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.example.client
+package com.smu_capstone_bigdata.client
 
 import io.flutter.embedding.android.FlutterActivity
 

--- a/android/app/src/profile/AndroidManifest.xml
+++ b/android/app/src/profile/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.client">
+    package="com.smu_capstone_bigdata.client">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->


### PR DESCRIPTION
## 개요
- 안드로이드 패키지명 (번들 id) 변경에 따른 파일 수정
- 변경전 패키지 명 : `com.smu-capstone-bigdata.client`
- 변경후 패키지 명 : `com.smu_capstone_bigdata.client`

## ⛑ 주의할 점
- ios의 번들 명은 `com.smu-capstone-bigdata.client` 그대로 입니다.

## 🛎 작업 내용
- main, debug, profile 폴더의 `AndroidManifest.xml` 의 패키지명 수정
- kotlin의 폴더 구조 변경: `kotlin/com.example.client` -> `kotlin/com.smu_capstone_bigdata.client`로 변경
- kotlin 폴더의 `MainActivity.kt`파일의 패키지명 변경: `import com.example.client` -> `import kotlin/com.smu_capstone_bigdata.client` 
