### PR TITLE
FIX: 카메라로 쓰레기통 찾을 시, 원래 존재하던 마커 삭제

### DIFF
--- a/lib/controllers/main-map-controller.dart
+++ b/lib/controllers/main-map-controller.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:client/utils/geolocator-service.dart';
 
+//맵 컨트롤러는 하나만 존재해야 합니다.
 MainMapController mainMapController = Get.put(MainMapController());
 
 class MainMapController extends GetxController {
@@ -107,22 +108,13 @@ class MainMapController extends GetxController {
   @override
   void nearestTrashcan() async {
     position = await GeolocatorService().getCurrentPosition();
-    final latitude = mainMapController.position?.latitude;
-    final longitude = mainMapController.position?.longitude;
+    final latitude = position?.latitude;
+    final longitude = position?.longitude;
 
-    dynamic nearestTrashcan = await getNearestTrashcan(
-        latitude!, longitude!, mainMapController.analysisData);
+    final nearestTrashcan = await coordinates(
+        latitude!, longitude!, analysisData);
 
-    if (nearestTrashcan == "") {
-      print("주변에 쓰레기통이 없습니다.");
-      nearestTrashcan =
-          await getNearestTrashcan(37.602638, 126.955252, analysisData);
-    }
-
-    address = nearestTrashcan['address'];
-    trashcanId = nearestTrashcan['id'];
-    trashcanType = nearestTrashcan['type'];
-    isVisible = true;
+    setMarker(nearestTrashcan);
 
     update();
   }

--- a/lib/controllers/main-map-controller.dart
+++ b/lib/controllers/main-map-controller.dart
@@ -100,12 +100,6 @@ class MainMapController extends GetxController {
   }
 
   @override
-  void falseIsVisible() {
-    isVisible = false;
-    update();
-  }
-
-  @override
   void nearestTrashcan() async {
     position = await GeolocatorService().getCurrentPosition();
     final latitude = position?.latitude;

--- a/lib/widgets/camera.dart
+++ b/lib/widgets/camera.dart
@@ -11,9 +11,6 @@ import 'package:geolocator/geolocator.dart';
 class UseCamera extends StatelessWidget {
   final controller = Get.put(CameraController());
 
-  MainMapController mainMapController =
-      Get.put(MainMapController()); // MainMapController 의존성 주입
-
   @override
   Widget build(BuildContext context) {
     return IconButton(

--- a/lib/widgets/main-map.dart
+++ b/lib/widgets/main-map.dart
@@ -36,7 +36,7 @@ class NaverMapWidget extends StatelessWidget {
                 locationButtonEnable: true,
                 markers: mainMapController.markers.toList(),
                 onMapTap: (position) {
-                  mainMapController.falseIsVisible();
+                  mainMapController.isVisible = false;
                 },
               ),
               Align(

--- a/lib/widgets/main-map.dart
+++ b/lib/widgets/main-map.dart
@@ -14,7 +14,6 @@ import 'package:get/get.dart'; // 상태관리용 GetX 패키지
 class NaverMapWidget extends StatelessWidget {
   NaverMapWidget({Key? key}) : super(key: key);
 
-  MainMapController mainMapController = Get.put(MainMapController());
 
   @override
   Widget build(BuildContext context) {
@@ -131,7 +130,6 @@ class RefreshBtn extends StatelessWidget {
       : this._controller = controller,
         super(key: key);
 
-  MainMapController mainMapController = Get.put(MainMapController());
 
   final Completer<NaverMapController> _controller;
 
@@ -169,7 +167,6 @@ class TrashClassificationDropdownButton extends StatelessWidget {
 
   DropdownController dropdownController =
       Get.put(DropdownController()); // DropdownController 의존성 주입
-  MainMapController mainMapController = Get.put(MainMapController());
 
   final Completer<NaverMapController> _controller;
 


### PR DESCRIPTION
## 개요
- 카메라로 쓰레기통 찾을 시, 원래 존재하던 마커 삭제

## ⛑ 주의할 점
- MainMapController는 하나만 존재해야 합니다.

## 🛎 작업 내용
- `falseIsVisible` 메서드 삭제 후, setter를 사용하도록 설정
- 주변에 쓰레기통이 없을 경우 반응이 없도록 수정
- 카메라로 쓰레기통을 찾을 시, 원래 존재하던 마커가 삭제되도록 수정
- 불필요한 의존성 주입 삭제
