### PR TITLE
FIX: 쓰레기통 찾기 시 정보를 표시함과 동시에 지도 이동 기능 추가

### DIFF
--- a/lib/controllers/main-map-controller.dart
+++ b/lib/controllers/main-map-controller.dart
@@ -79,6 +79,29 @@ class MainMapController extends GetxController {
     update();
   }
 
+  void setSingleMarker(dynamic coordinate) {
+    markers.clear();
+
+    markers.add(
+      Marker(
+        markerId: coordinate['id'].toString(),
+        position: LatLng(double.parse(coordinate['latitude']),
+            double.parse(coordinate['longitude'])),
+        width: 20,
+        height: 30,
+        onMarkerTab: (marker, iconSize) {
+          address = coordinate['address'];
+          trashcanType = coordinate['type'];
+          trashcanId = coordinate['id'];
+          isVisible = true;
+          update();
+        },
+      ),
+    );
+
+    update();
+  }
+
   @override
   void onInit() {
     super.onInit();
@@ -104,12 +127,32 @@ class MainMapController extends GetxController {
     position = await GeolocatorService().getCurrentPosition();
     final latitude = position?.latitude;
     final longitude = position?.longitude;
+    final mapController = await controller.future;
+
+    // final latitude = 37.602638;
+    // final longitude = 126.955252; 테스트용 좌표입니다.
 
     final nearestTrashcan =
-        await coordinates(latitude!, longitude!, analysisData);
+        await getNearestTrashcan(latitude!, longitude!, analysisData);
 
-    setMarker(nearestTrashcan);
+    address = nearestTrashcan['address'];
+    trashcanId = nearestTrashcan['id'];
+    trashcanType = nearestTrashcan['type'];
+    isVisible = true;
 
+    setSingleMarker(nearestTrashcan);
+
+    CameraUpdate cameraUpdate = CameraUpdate.toCameraPosition(CameraPosition(
+        target: LatLng(double.parse(nearestTrashcan['latitude']),
+            double.parse(nearestTrashcan['longitude']))));
+
+    mapController.moveCamera(cameraUpdate);
+
+    update();
+  }
+
+  falseIsVisible() {
+    isVisible = false;
     update();
   }
 }

--- a/lib/widgets/main-map.dart
+++ b/lib/widgets/main-map.dart
@@ -37,19 +37,13 @@ class NaverMapWidget extends StatelessWidget {
                 locationButtonEnable: true,
                 markers: mainMapController.markers.toList(),
                 onMapTap: (position) {
-                  mainMapController.isVisible = false;
+                  mainMapController.falseIsVisible();
                 },
               ),
-              Align(
-                  alignment: Alignment.bottomRight,
-                  child: RefreshBtn(
-                    controller: mainMapController.controller,
-                  )),
+              Align(alignment: Alignment.bottomRight, child: RefreshBtn()),
               Align(
                 alignment: Alignment.topCenter,
-                child: TrashClassificationDropdownButton(
-                  controller: mainMapController.controller,
-                ), // 쓰레기통 종류 드랍다운
+                child: TrashClassificationDropdownButton(), // 쓰레기통 종류 드랍다운
               ),
 
               // 쓰레기통 정보 표시
@@ -147,14 +141,10 @@ class NaverMapWidget extends StatelessWidget {
 
 //새로고침으로 근처 쓰레기통 마커를 가져오는 버튼
 class RefreshBtn extends StatelessWidget {
-  RefreshBtn({Key? key, required Completer<NaverMapController> controller})
-      : this._controller = controller,
-        super(key: key);
-
-  final Completer<NaverMapController> _controller;
+  RefreshBtn({Key? key}) : super(key: key);
 
   refresh() async {
-    final controller = await _controller.future;
+    final controller = await mainMapController.controller.future;
     final xy = await controller.getCameraPosition();
     final double latitude = xy.target.latitude;
     final double longitude = xy.target.longitude;
@@ -180,18 +170,13 @@ class RefreshBtn extends StatelessWidget {
 
 // 쓰레기통종류 드랍다운 버튼 with GetX
 class TrashClassificationDropdownButton extends StatelessWidget {
-  TrashClassificationDropdownButton(
-      {Key? key, required Completer<NaverMapController> controller})
-      : this._controller = controller,
-        super(key: key);
+  TrashClassificationDropdownButton({Key? key}) : super(key: key);
 
   DropdownController dropdownController =
       Get.put(DropdownController()); // DropdownController 의존성 주입
 
-  final Completer<NaverMapController> _controller;
-
   refresh() async {
-    final controller = await _controller.future;
+    final controller = await mainMapController.controller.future;
     final xy = await controller.getCameraPosition();
     final double latitude = xy.target.latitude;
     final double longitude = xy.target.longitude;


### PR DESCRIPTION
## 개요
- 쓰레기통 찾기 시 정보를 표시함과 동시에 지도 이동 기능 추가

## ⛑ 주의할 점
- `main-map-controller.dart` 에 `falseIsVisible()` 함수 다시 추가( 그냥 쓰면 update 가 안 되서 작동 안 합니다. )

## 🛎 작업 내용
- `main-map-controller.dart` 에 단일 쓰레기통 마커 추가하는 함수 구현
- `main-map-controller.dart` 에 쓰레기통 찾기 시 지도의 위치를 쓰레기통 위치로 전환하는 로직 추가
